### PR TITLE
Change version of MathJax to 2.7

### DIFF
--- a/AP Chem/Unit 7.html
+++ b/AP Chem/Unit 7.html
@@ -36,7 +36,7 @@
             <equation>k<sub>eq</sub> &gt; 1</equation>, the reaction favors the forwards direction since there is a higher concentration of products.</li>
         <li>Reversible reactions at equilibrium with different states of matter are said to be in <u>Heterogeneous Equilibrium</u>. In these cases we ignore the solvents and the solids because they are in excess, so it makes sense to not take into account
             such high concentrations into our formula for the equilibrium constant.</li>
-        <li>In equilibrium reactions, pay attention to the state of matter. <strong style="color:mediumvioletred;">Concentrations of solids and liquids are omitted from all calculations</strong>.</li>
+        <li>In equilibrium reactions, pay attention to the state of matter. <strong style="color:mediumvioletred;">Concentrations of solids and liquids are omitted from all calculations</strong>. Another way to think of this is that liquids and solids don't have concentrations to begin with, there is no such thing as stronger water.</li>
     </ul>
     <h5>Le Ch&acirc;telier's Principle:</h5>
     <ul>

--- a/renderMath.js
+++ b/renderMath.js
@@ -87,8 +87,6 @@ function renderMath(parentElement = "") {
             <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
             */
-            // var polyfillScript = document.createElement("script");
-            // polyfillScript.setAttribute("src", "https://polyfill.io/v3/polyfill.min.js?features=es6");
             var mathjaxScript = document.createElement("script");
             mathjaxScript.setAttribute("type", "text/javascript");
             mathjaxScript.setAttribute("async", "");

--- a/renderMath.js
+++ b/renderMath.js
@@ -231,7 +231,7 @@ function renderMath(parentElement = "") {
                     var newBR = createHTMLNodesFromString("\n\\\\\n");
                     oldBR.replaceWith(...newBR);
                 }
-                oldSpanAlignedEquations.innerHTML = oldSpanAlignedEquations.innerHTML.replace(/=/g, "&=");
+                oldSpanAlignedEquations.innerHTML = oldSpanAlignedEquations.innerHTML.replace(/=/g, "&=").replace(/\-\>/gm, "&->").replace(/\-&gt;/gm, "&->");
                 var newSpanAlignedEquations = createHTMLNodesFromString("\\begin{align}" + oldSpanAlignedEquations.innerHTML + "\\end{align}");
                 oldSpanAlignedEquations.replaceWith(...newSpanAlignedEquations);
             }

--- a/renderMath.js
+++ b/renderMath.js
@@ -52,22 +52,31 @@ function renderMath(parentElement = "") {
         //If sessionStorage doesn't have pages saved where mathjax was loaded or if this page hasn't already loaded mathjax
         if (!sessionStorage.getItem("pagesThatLoadedMathJax") || !JSON.parse(sessionStorage.getItem("pagesThatLoadedMathJax")).includes(window.location.href))
         */
+        
         if (document.querySelector("#MathJax-Script") == null) {
             //Set MathJax Config
+            
             window.MathJax = {
                 chtml: {
-                    scale: 1.3
+                    scale: 1
                 },
                 options: {
-                    enableMenu: false
+                    enableMenu: true
                 },
-                tex: {
+                TeX: {
                     packages: {
                         '[+]': ['mhchem']
-                    }
+                    },
+                    extensions: ['mhchem.js']
                 },
                 loader: {
                     load: ['[tex]/mhchem']
+                },
+                styles: {
+
+                    ".MathJax_Display": {
+                      "overflow-x": "auto",
+                    }
                 }
             };
             /*
@@ -78,13 +87,12 @@ function renderMath(parentElement = "") {
             <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
             */
-            var polyfillScript = document.createElement("script");
-            polyfillScript.setAttribute("src", "https://polyfill.io/v3/polyfill.min.js?features=es6");
+            // var polyfillScript = document.createElement("script");
+            // polyfillScript.setAttribute("src", "https://polyfill.io/v3/polyfill.min.js?features=es6");
             var mathjaxScript = document.createElement("script");
-            mathjaxScript.setAttribute("id", "MathJax-script");
+            mathjaxScript.setAttribute("type", "text/javascript");
             mathjaxScript.setAttribute("async", "");
-            mathjaxScript.setAttribute("src", "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js");
-            document.head.appendChild(polyfillScript);
+            mathjaxScript.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML");
             document.head.appendChild(mathjaxScript);
 
             /*
@@ -223,7 +231,7 @@ function renderMath(parentElement = "") {
                     var newBR = createHTMLNodesFromString("\n\\\\\n");
                     oldBR.replaceWith(...newBR);
                 }
-                oldSpanAlignedEquations.innerHTML = oldSpanAlignedEquations.innerHTML.replace(/=/g, "&=").replace(/\-\>/gm, "&->").replace(/\-&gt;/gm, "&->");
+                oldSpanAlignedEquations.innerHTML = oldSpanAlignedEquations.innerHTML.replace(/=/g, "&=");
                 var newSpanAlignedEquations = createHTMLNodesFromString("\\begin{align}" + oldSpanAlignedEquations.innerHTML + "\\end{align}");
                 oldSpanAlignedEquations.replaceWith(...newSpanAlignedEquations);
             }

--- a/renderMath.js
+++ b/renderMath.js
@@ -92,7 +92,7 @@ function renderMath(parentElement = "") {
             var mathjaxScript = document.createElement("script");
             mathjaxScript.setAttribute("type", "text/javascript");
             mathjaxScript.setAttribute("async", "");
-            mathjaxScript.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML");
+            mathjaxScript.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js");
             document.head.appendChild(mathjaxScript);
 
             /*

--- a/renderMath.js
+++ b/renderMath.js
@@ -51,10 +51,10 @@ function renderMath(parentElement = "") {
         //If sessionStorage doesn't have pages saved where mathjax was loaded or if this page hasn't already loaded mathjax
         if (!sessionStorage.getItem("pagesThatLoadedMathJax") || !JSON.parse(sessionStorage.getItem("pagesThatLoadedMathJax")).includes(window.location.href))
         */
-        
+
         if (document.querySelector("#MathJax-Script") == null) {
             //Set MathJax Config
-            
+
             window.MathJax = {
                 chtml: {
                     scale: 1
@@ -70,26 +70,39 @@ function renderMath(parentElement = "") {
                 },
                 loader: {
                     load: ['[tex]/mhchem']
-                },
+                }
+                /*,
                 styles: {
 
                     ".MathJax_Display": {
-                      "overflow-x": "auto",
+                        "overflow-x": "auto",
                     }
-                }
+                }*/
             };
+            /*
+            MathJax.Hub.Config({
+                text2jax: {
+                    inlineMath: [
+                        ["\\(", "\\)"]
+                    ]
+                }
+            });
+            */
             /*
             Import MathJax
             <!--Use this to edit MathJax: https://en.wikipedia.org/wiki/Quadratic_equation?veaction=edit-->
-            <!-- Import MathJax -->
+            <!-- Import MathJax 3.x -->
             <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
             <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-
+            <!-- Import MathJax 2.7 -->
+            <script id="MathJax-script" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js"></script>
             */
             var mathjaxScript = document.createElement("script");
-            mathjaxScript.setAttribute("type", "text/javascript");
-            mathjaxScript.setAttribute("async", "");
+            mathjaxScript.setAttribute("id", "MathJax-script");
             mathjaxScript.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js");
+            mathjaxScript.innerHTML = "MathJax.Hub.Config({\n" +
+                "  tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] }\n" +
+                "});";
             document.head.appendChild(mathjaxScript);
 
             /*


### PR DESCRIPTION
Changing the version will provide more options for us as the newest version of MathJax has not updated all its components yet.
Doing so will not change any prior work we have done.